### PR TITLE
Correct redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,8 @@
 [[redirects]]
   from = "/apply"
-  to = "https://docs.google.com/forms/d/11YtXsa1IGrZpFNq3aFNUMPivyBCzqrArihGK_W5EuKk/edit?usp=sharing"
+  to = "https://forms.gle/i68cT5S3mhcQiXbq7"
 
-  
+
 [[redirects]]
   from = "/rsvp"
-  to = "https://docs.google.com/forms/d/1hwe2oc95-vYFa93a-s4YSIy52cDDesLpl4bR_04PGlM/edit?usp=sharing"
+  to = "https://forms.gle/StXKhkycSh78iqNS8"


### PR DESCRIPTION
Update the /apply and /rsvp site paths to redirect to non-editable google forms.