### PR TITLE
Update Editor's note byline on Post page

### DIFF
--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -47,7 +47,7 @@ const Post = (props: { data }) => {
           }
           {category.toLowerCase() === "issue heading" &&
             <div className="post-byline">
-            by {`${author_list}`.toLowerCase()}
+            {`${author_list}`.toLowerCase()}
             </div>
           }
         </div>


### PR DESCRIPTION
New format: whatever is entered in article_authors on wp is displayed in the context for articles that have category 'Issue Heading'