### PR TITLE
New Image Paradigm

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -33,6 +33,7 @@ exports.createPages = async ({ graphql, actions }) => {
             date
             featuredImage {
               node {
+		sourceUrl
                 localFile {
                   childImageSharp {
                     fixed {

--- a/src/hooks/landing_top_query.tsx
+++ b/src/hooks/landing_top_query.tsx
@@ -20,6 +20,7 @@ export const useLandingQuery = () => {
                         }
                       }
                     }
+		    sourceUrl
                   }
                 }
                 date

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -53,7 +53,7 @@ const Title = () => {
     const selected_article = selected_articles.allWpPost.edges[index].node
     const selected_article_name = selected_article.title
     const selected_article_slug = "/post/" + selected_article.slug
-    const selected_article_img = selected_article.featuredImage.node.localFile.childImageSharp.fixed.src
+    const selected_article_img = selected_article.featuredImage.node.sourceUrl
     var issue_name = selected_articles.allWpPost.edges[index].node.categories.nodes[0].name
     var other_articles = []
     for (let i = 0; i <= 3; i++) {
@@ -105,7 +105,7 @@ export const ArticleTile = ({ node, img }) => {
       <Link to={"/post/"+node.slug}>
         <div className="landing-columns">
             <div className="landing-col-a">
-                <img id="landing-article-thumbnail" src={img || node.featuredImage?.node.localFile.childImageSharp.fixed.src || temp_article_thumbnail} alt="article image" />
+                <img id="landing-article-thumbnail" src={img || node.featuredImage?.node.sourceUrl || temp_article_thumbnail} alt="article image" />
             </div>
             <div className="landing-col-b">
                 <h1 id="article-title">
@@ -231,6 +231,7 @@ export const pageQuery = graphql`
                   }
                 }
                 date
+		sourceUrl
               }
             }
             excerpt

--- a/src/templates/issue.tsx
+++ b/src/templates/issue.tsx
@@ -30,7 +30,7 @@ const ArticleTile = ({ article }) => {
             <Link to={"/post/"+article.slug}>
             <div className="columns">
                 <div className="col-a">
-                <img id="article-thumbnail" src={article.featuredImage ? article.featuredImage.node.localFile.childImageSharp.fixed.src : temp_article_thumbnail} alt="article image" />
+                <img id="article-thumbnail" src={article.featuredImage ? article.featuredImage.node.sourceUrl : temp_article_thumbnail} alt="article image" />
                 </div>
                 <div className="col-b">
                 <h1 id="article-title">
@@ -64,7 +64,7 @@ class Issue extends Component {
                   image={this.props.pageContext.featuredImage.node.localFile.url} />
                 <Layout useDarkSquiggles={true} squiggleTopOffset={1} squiggleCadence={1.5}>
                     {fadeInUp(<div>
-                        <img id="issue-image" src={this.props.pageContext.featuredImage ? this.props.pageContext.featuredImage.node.localFile.childImageSharp.fixed.src : temp_issue_cover} alt="issue cover image" />
+                        <img id="issue-image" src={this.props.pageContext.featuredImage ? this.props.pageContext.featuredImage.node.localFile.url : temp_issue_cover} alt="issue cover image" />
                         <h1 id="issue-title">
                             {this.props.pageContext.title}
                         </h1>
@@ -163,6 +163,7 @@ export const issueQuery = graphql`
                                 }
                             }
                         }
+			sourceUrl
                     }
                 }
 		tags {

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -25,7 +25,7 @@ const Post = (props: { data }) => {
   const category = props.data.wpPost?.categories?.nodes?.length
     ? props.data.wpPost?.categories?.nodes[0].name
     : "uncategorized"
-  const featuredImage = post?.featuredImage?.node?.localFile?.childImageSharp?.fixed?.src
+  const featuredImage = post?.featuredImage?.node?.sourceUrl
   const featuredImage_url = post?.featuredImage?.node?.localFile.url
 
   const subtitle = post?.article_fields?.articleSubtitle
@@ -113,6 +113,7 @@ export const postQuery = graphql`
             }
             url
           }
+          sourceUrl
         }
       }
       author {

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -25,7 +25,7 @@ const Post = (props: { data }) => {
   const category = props.data.wpPost?.categories?.nodes?.length
     ? props.data.wpPost?.categories?.nodes[0].name
     : "uncategorized"
-  const featuredImage = post?.featuredImage?.node?.localFile.childImageSharp.fixed.src
+  const featuredImage = post?.featuredImage?.node?.localFile?.childImageSharp?.fixed?.src
   const featuredImage_url = post?.featuredImage?.node?.localFile.url
 
   const subtitle = post?.article_fields?.articleSubtitle


### PR DESCRIPTION
- Support full quality images and gifs throughout the site.
- Implemented with sourceUrl rather than fixed image.
- Potential problem - pages take too long too load when there are many large images.
- TODO: use gatsby-image for lazy loading of images.