### PR TITLE
AntiTrust issue release

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -15,6 +15,18 @@ function Navlink(props) {
   )
 }
 
+function NavlinkSub(props) {
+  return (
+    <Link
+      to={props.to}
+      className={"navbar-link-sub"}
+      activeClassName={"navbar-link-sub active"}
+    >
+      {props.children.toLowerCase()}
+    </Link>
+  )
+}
+
 function navbar() {
   /*
                     <div id="navbar-brand-stanford">
@@ -30,12 +42,22 @@ function navbar() {
       </Link>
       <div className="navbar-element-wrap">
         <div className="navbar-elements">
-          <Navlink bold to="/issue/governance">
-            Issue One
+          <Navlink bold to="/issue/antitrust">
+            Issue Three
           </Navlink>
-          <Navlink bold to="/issue/viral">
-            Issue Two
-          </Navlink>
+
+	  <div className="dropdown">
+          <a className="navbar-link">Past Issues</a>
+	  <div className="dropdown-content">
+            <NavlinkSub bold to="/issue/governance">
+              Issue One
+            </NavlinkSub>
+            <NavlinkSub bold to="/issue/viral">
+              Issue Two 
+            </NavlinkSub>
+          </div>
+          </div>
+
           <Navlink to="/about">About</Navlink>
         </div>
       </div>

--- a/src/hooks/landing_top_query.tsx
+++ b/src/hooks/landing_top_query.tsx
@@ -5,7 +5,7 @@ export const useLandingQuery = () => {
   const selected_article = useStaticQuery (
     graphql`
       query {
-          allWpPost(filter: {categories: {nodes: {elemMatch: {name: {eq: "Viral"}}}}}) {
+          allWpPost(filter: {categories: {nodes: {elemMatch: {name: {eq: "(Anti)Trust"}}}}}) {
             edges {
               node {
                 slug

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -83,7 +83,7 @@ const Title = () => {
             } */}
             <p id="landing-description">
                 Our latest issue, <i>{issue_name}</i>,
-                includes articles such as "{other_articles[0]}," "{other_articles[1]}," and "{other_articles[2]}." <Link to={"/issue/"+issue_name.toLowerCase()}>Read the issue &rarr;</Link>
+                includes articles such as "{other_articles[0]}," "{other_articles[1]}," and "{other_articles[2]}." <Link to={"/issue/"+issue_name.toLowerCase().replace("(", "").replace(")", "")}>Read the issue &rarr;</Link>
             </p>
         </div>
     )

--- a/src/styles/navbar.scss
+++ b/src/styles/navbar.scss
@@ -95,6 +95,7 @@
 .dropdown-content {
   display: none;
   position: absolute;
+  background: $background;
 }
 
 .dropdown {

--- a/src/styles/navbar.scss
+++ b/src/styles/navbar.scss
@@ -80,3 +80,28 @@
     font-weight: 600;
   }
 }
+
+.navbar-link-sub {
+  @extend .sans-serif-caps;
+  font-variant: small-caps;
+  margin-right: 2rem;
+  display: block;
+
+  &.active {
+    font-weight: 600;
+  }
+}
+
+.dropdown-content {
+  display: none;
+  position: absolute;
+}
+
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.dropdown:hover .dropdown-content{display: block;}
+
+

--- a/src/templates/issue.tsx
+++ b/src/templates/issue.tsx
@@ -73,7 +73,7 @@ class Issue extends Component {
                         </h1>
                         <p id="description">
                             <span dangerouslySetInnerHTML={{ __html: this.props.pageContext.excerpt }}></span>
-                            <Link to={"/post/"+this.props.pageContext.title.toLowerCase()}>
+                            <Link to={"/post/"+this.props.pageContext.title.toLowerCase().replace("(", "").replace(")", "")}>
                                             Read the editor's note &rarr;
                             </Link>
                         </p>

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -44,7 +44,7 @@ const Post = (props: { data }) => {
           {category.toLowerCase() != "issue heading" &&
             <div className="post-byline">
             by {`${author_list}`.toLowerCase()} • in{" "}
-            <Link className="post-category" to={"/issue/"+category.toLowerCase()}>
+            <Link className="post-category" to={"/issue/"+category.toLowerCase().replace("(", "").replace(")", "")}>
               {category.toLowerCase()}
             </Link>
             </div>


### PR DESCRIPTION
- Support new tab schema for current issue and previous issues with drop down
- Manage the edge case of issue names having inappropriate slug characters ()
- Update the home page to pull from antitrust rather than viral